### PR TITLE
improving _core_computation

### DIFF
--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -57,14 +57,23 @@ def calc_inbag(n_samples, forest):
     return inbag
 
 
-def _core_computation(X_train, X_test, inbag, pred_centered, n_trees):
-    cov_hat = np.zeros((X_train.shape[0], X_test.shape[0]))
-
-    for t_idx in range(n_trees):
-        inbag_r = (inbag[:, t_idx] - 1).reshape(-1, 1)
-        pred_c_r = pred_centered.T[t_idx].reshape(1, -1)
-        cov_hat += np.dot(inbag_r, pred_c_r) / n_trees
-    V_IJ = np.sum(cov_hat ** 2, 0)
+def _core_computation(X_train, X_test, inbag, pred_centered, n_trees, memory_constrained=False, memory_limit=None):
+    if not memory_constrained:
+        return np.sum((np.dot(inbag-1,pred_centered.T)/n_trees)**2,0)
+    
+    if not memory_limit:
+        raise ValueError('If memory_constrained=True, must provide memory_limit.')
+    
+    chunk_size = int((memory_limit * 1e6) /(8.0 * X_train.shape[0]))
+    
+    if chunk_size==0:
+        min_limit = 8.0*X_train.shape[0]/(1e6)
+        raise ValueError('memory_limit provided is too small. For these dimensions, memory_limit must be greater than or equal to %.3e' % min_limit)
+    
+    chunk_edges = np.arange(0,X_test.shape[0]+chunk_size,chunk_size)
+    inds = range(X_test.shape[0])
+    chunks = [inds[chunk_edges[i]:chunk_edges[i+1]] for i in range(len(chunk_edges)-1)]
+    V_IJ = np.concatenate([np.sum((np.dot(inbag-1,pred_centered[chunk].T)/n_trees)**2,0) for chunk in chunks])
     return V_IJ
 
 
@@ -78,7 +87,7 @@ def _bias_correction(V_IJ, inbag, pred_centered, n_trees):
     return V_IJ_unbiased
 
 
-def random_forest_error(forest, X_train, X_test, inbag=None):
+def random_forest_error(forest, X_train, X_test, inbag=None, memory_constrained=False, memory_limit=None):
     """
     Calculates error bars from scikit-learn RandomForest estimators.
 
@@ -90,8 +99,11 @@ def random_forest_error(forest, X_train, X_test, inbag=None):
     forest : RandomForest
         Regressor or Classifier object.
 
-    X : ndarray
-        An array with shape (n_sample, n_features).
+    X_train : ndarray
+        An array with shape (n_train_sample, n_features).
+
+    X_test : ndarray
+        An array with shape (n_test_sample, n_features).
 
     inbag : ndarray (optional)
         The inbag matrix that fit the data. If set to `None` (default) it
@@ -99,6 +111,16 @@ def random_forest_error(forest, X_train, X_test, inbag=None):
         for which bootstrapping was set to `True`. That is, if sampling was
         done with replacement. Otherwise, users need to provide their own
         inbag matrix.
+
+    memory_constrained: boolean (optional)
+        Whether or not there is a restriction on memory. If False, it is 
+        assumed that a ndarry of shape (n_train_sample,n_test_sample) fits
+        in main memory. Setting to True can actually provide a speed up if
+        memory_limit is tuned to the optimal range.
+
+    memory_limit: int (optional)
+        An upper bound for how much memory the itermediate matrices will take
+        up in Megabytes. This must be provided if memory_constrained=True.
 
     Returns
     -------
@@ -125,7 +147,7 @@ def random_forest_error(forest, X_train, X_test, inbag=None):
     pred_mean = np.mean(pred, 0)
     pred_centered = pred - pred_mean
     n_trees = forest.n_estimators
-    V_IJ = _core_computation(X_train, X_test, inbag, pred_centered, n_trees)
+    V_IJ = _core_computation(X_train, X_test, inbag, pred_centered, n_trees, memory_constrained, memory_limit)
     V_IJ_unbiased = _bias_correction(V_IJ, inbag, pred_centered, n_trees)
 
     # Correct for cases where resampling is done without replacement:

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -47,17 +47,26 @@ def test_core_computation():
     X_train_ex = np.array([[3, 3],
                            [6, 4],
                            [6, 6]])
-    X_test_ex = np.array([[5, 2],
-                          [5, 5]])
-    pred_centered_ex = np.array([[-20, -20, 10, 30], [-20, 30, -20, 10]])
+    X_test_ex = np.vstack([np.array([[5, 2],
+                                     [5, 5]]) for _ in range(1000)])
+    pred_centered_ex = np.vstack([np.array([[-20, -20, 10, 30],
+                                            [-20, 30, -20, 10]])
+                                  for _ in range(1000)])
     n_trees = 4
 
     our_vij = fci._core_computation(X_train_ex, X_test_ex, inbag_ex,
                                     pred_centered_ex, n_trees)
 
-    r_vij = np.array([112.5, 387.5])
+    r_vij = np.concatenate([np.array([112.5, 387.5]) for _ in range(1000)])
 
     npt.assert_almost_equal(our_vij, r_vij)
+
+    our_vij = fci._core_computation(X_train_ex, X_test_ex, inbag_ex,
+                                    pred_centered_ex, n_trees,
+                                    memory_constrained=True, memory_limit=.01, 
+                                    test_mode=True)
+
+    npt.assert_almost_equal(our_vij, r_vij)    
 
 
 def test_bias_correction():


### PR DESCRIPTION
Hello,

Was playing around with this last night and ran into memory issues. I was trying to get some confidence estimates for a forest with 1 million training examples and 300k testing examples. The line `cov_hat = np.zeros((X_train.shape[0], X_test.shape[0]))` was giving me Memory Errors since having this matrix in memory would take over 300GB.

I realized a couple things:

1. The function _core_computation was not fully vectorized. It was implemented by summing outer products instead of just one matrix multiplication. With my testing, doing this multiplication all at once is around 5-10x faster with no additional memory requirements.

2. If a matrix of shape (n_train_sample,n_test_sample) cannot fit in memory, this function did not work at all. However, this is easy to deal with since we can deal with chunks of the pred_centered matrix at a time. I implemented this by adding a couple arguments to _core_computation and random_forest_error that allow the user to specify if they have memory constraints and if so what is the maximum memory an intermediate matrix should take up in megabytes. To my surprise, if memory_limit is tuned decently, this method is actually even faster than the whole matrix at one time method by around 3x (even if it's unnecessary and the whole matrix can fit in memory).

![times_for_7k_by_9k](https://cloud.githubusercontent.com/assets/6889910/21529774/cfa02f2e-ccf0-11e6-9271-1de64a963ade.png)

In summary, these improvements can speedup the _core_computation function up to 15-30x if the user plays with the memory_limit arguments or 5-10x if he or she does not. It also allows the function to work when a matrix of shape (n_train_sample,n_test_sample) cannot fit into memory.

All tests currently in the repo pass on python 2 and 3. I can add tests for when memory_constrained=True if it is desired. Please let me know if you have any comments or questions.

Thanks