### PR TITLE
Add low memory implementation of core computation

### DIFF
--- a/forestci/__init__.py
+++ b/forestci/__init__.py
@@ -1,4 +1,5 @@
 from .forestci import (calc_inbag, random_forest_error,
+                       _cycore_computation,
                        _core_computation, _bias_correction)  # noqa
 
 from .version import __version__  # noqa

--- a/forestci/cyfci.pyx
+++ b/forestci/cyfci.pyx
@@ -1,0 +1,64 @@
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: nonecheck=False
+from numpy cimport ndarray
+cimport numpy
+import numpy
+cimport cython
+from cython.parallel cimport prange
+cimport scipy.linalg.cython_blas as blas
+
+def _cycore_computation(inbag, pred_centered):
+    """
+    Helper function performs core computation using cython
+    and avoids storing intermediate matrices in-memory.
+
+    Parameters
+    ----------
+    inbag: ndarray
+        The inbag matrix that fit the data. If set to `None` (default) it
+        will be inferred from the forest. However, this only works for trees
+        for which bootstrapping was set to `True`. That is, if sampling was
+        done with replacement. Otherwise, users need to provide their own
+        inbag matrix.
+
+    pred_centered : ndarray
+        Centered predictions that are an intermediate result in the
+        computation.
+    """
+    result = numpy.zeros(pred_centered.shape[0], dtype=numpy.float64)
+    inbag = inbag-1
+    _matmul_colsum(inbag, pred_centered, result)
+    return result
+
+cdef _matmul_colsum(double[:,::1] a, double[:,::1] b, double[::1] c):
+    """
+    Matrix multiply `a` and `b` and then sum over columns without
+    storing the intermediate matrix (a dot b) in memory.
+    Result is stored in `c`.
+    Equivalent to `numpy.sum(numpy.dot(a,b), axis=0)`
+
+    Parameters
+    ----------
+    a: ndarray
+       `(n,p)` 2d input array
+
+    b: ndarray
+        `(p,m)` 2d input array
+
+    c: ndarray
+        `(m)` 1d output array (data overwritten with result)
+
+    Returns
+    -------
+    None
+    """
+    cdef int i, j
+    cdef int n=a.shape[0], m=b.shape[0], B=a.shape[1]
+    cdef int ONE=1
+    cdef double x=0.0;
+    for i in prange(m, nogil=True, schedule='static'):
+        x = 0.0
+        for j in range(n):
+            x = x + blas.ddot(&B, &(a[j,0]), &ONE, &(b[i,0]), &ONE) ** 2
+        c[i] = x / B**2

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -10,7 +10,7 @@ def test_compare_cycore_computation():
     b = np.arange(1,13,dtype=np.float64).reshape(4,3)
     c = fci._cycore_computation(a, b)
     actual = fci._core_computation(np.zeros((2,10)), np.zeros((4,10)), a, b, 3)
-    npt.assert_equal(actual, c)
+    npt.assert_almost_equal(actual, c)
 
 
 def test_random_forest_error():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy>= 1.8.2
 nose>=1.1.2
 scikit-learn>=0.17
+cython
+scipy

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import sys, os
 from setuptools import setup, find_packages
+from setuptools.extension import Extension
 
 with open('requirements.txt') as f:
     INSTALL_REQUIRES = [l.strip() for l in f.readlines() if l]
@@ -22,6 +23,13 @@ ver_file = os.path.join('forestci', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
 
+ext = Extension(
+    'forestci.cyfci',
+    ['forestci/cyfci.pyx'],
+    include_dirs=[numpy.get_include()],
+    extra_compile_args=['-O3', '-fopenmp'],
+    extra_link_args=['-fopenmp'])
+
 opts = dict(name=NAME,
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
@@ -36,7 +44,8 @@ opts = dict(name=NAME,
             platforms=PLATFORMS,
             version=VERSION,
             packages=find_packages(),
-            install_requires=INSTALL_REQUIRES)
+            install_requires=INSTALL_REQUIRES,
+            ext_modules=[ext])
 
 if __name__ == '__main__':
     setup(**opts)


### PR DESCRIPTION
Computing confidence intervals on large datasets is extremely memory intensive because of the following matrix multiplication: inbag (n_train_samples, n_trees) X pred_centered.T (n_trees, n_test_samples) = result (n_train_samples, n_test_samples).

I've added the low_memory option, which avoids storing this result matrix by performing the column sum for each dot product in the matrix multiplication. Adds dependencies on scipy and cython however.

 - use cython to do matrix multiplication and column sum (cython dependency)
 - avoid storing intemediate matrix
 - use scipy blas functions (add scipy dependency)
 - expose cython version as `low_memory` option
 - change memory options in `random_forest_error` interface
 - add tests for cython implementation
 - first cython test failing but appears correct (from pytest logs)

**Performance:**

The cython implementation (`low_memory=True`) is always slower than the numpy implementation when the `inbag.dot(pred_centered.T)` fits in memory (numpy is amazing). As the problem size increases, the numpy advantage increases further.

The cython implementation becomes useful when the matrix product is larger than memory. In that case, the performance hit (at least in the following example) is less than the time taken to allocate and reallocate chunked memory.

For 7,000,000 training samples, 10,000 test samples, and a forest of 100 estimators (and 32 core machine):
 - numpy: 27min
 - cython: 15min