### PR TITLE
utilize n_samples_bootstrap when generating sample indices

### DIFF
--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -8,7 +8,7 @@ RandomForestClassifier predictions.
 import numpy as np
 import copy
 from .calibration import calibrateEB
-from sklearn.ensemble.forest import _generate_sample_indices
+from sklearn.ensemble.forest import _generate_sample_indices, _get_n_samples_bootstrap
 from .due import _due, _BibTeX
 
 __all__ = ("calc_inbag", "random_forest_error", "_bias_correction",
@@ -59,10 +59,14 @@ def calc_inbag(n_samples, forest):
     n_trees = forest.n_estimators
     inbag = np.zeros((n_samples, n_trees))
     sample_idx = []
+    n_samples_bootstrap = _get_n_samples_bootstrap(
+        n_samples, forest.max_samples
+    )
+
     for t_idx in range(n_trees):
         sample_idx.append(
             _generate_sample_indices(forest.estimators_[t_idx].random_state,
-                                     n_samples))
+                                     n_samples, n_samples_bootstrap))
         inbag[:, t_idx] = np.bincount(sample_idx[-1], minlength=n_samples)
     return inbag
 


### PR DESCRIPTION
> This is a breaking change. It requires scikit learn version >= 0.22.
> Backward compatibility will be done if it is required.

`scikit learn` has introduced a new parameter `n_samples_bootstrap` when generating sample indices [in v0.22](https://github.com/scikit-learn/scikit-learn/commit/746efb580a1012c580282498359d1bfed91186a2):

https://github.com/scikit-learn/scikit-learn/blob/07ceb6e2552a8af5e35dd652d24989b6a69dd7c7/sklearn/ensemble/_forest.py#L115-L122

The new parameter is generated by the function `_get_n_samples_bootstrap`:

https://github.com/scikit-learn/scikit-learn/blob/07ceb6e2552a8af5e35dd652d24989b6a69dd7c7/sklearn/ensemble/_forest.py#L76-L112

This PR added this new parameter to the package so that one can use it on scikit learn version >= 0.22.