### PR TITLE
Fix an averaging bug that has been referred to in issue #80

### DIFF
--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -236,7 +236,7 @@ def random_forest_error(forest, X_train, X_test, inbag=None,
         inbag = calc_inbag(X_train.shape[0], forest)
 
     pred = np.array([tree.predict(X_test) for tree in forest]).T
-    pred_mean = np.mean(pred, 0)
+    pred_mean = np.mean(pred, 1).reshape(X_test.shape[0], 1)
     pred_centered = pred - pred_mean
     n_trees = forest.n_estimators
     V_IJ = _core_computation(X_train, X_test, inbag, pred_centered, n_trees,

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -117,3 +117,43 @@ def test_with_calibration():
         forest.fit(X_train, y_train)
         V_IJ_unbiased = fci.random_forest_error(forest, X_train, X_test)
         npt.assert_equal(V_IJ_unbiased.shape[0], y_test.shape[0])
+
+
+def test_centered_prediction_forest():
+    X = np.array([[5, 2],
+                  [5, 5],
+                  [3, 3],
+                  [6, 4],
+                  [6, 6]])
+
+    y = np.array([70, 100, 60, 100, 120])
+
+    train_idx = [2, 3, 4]
+    test_idx = [0, 1]
+
+    y_test = y[test_idx]
+    y_train = y[train_idx]
+    X_test = X[test_idx]
+    X_train = X[train_idx]
+
+    n_trees = 8
+    forest = RandomForestRegressor(n_estimators=n_trees)
+    forest = forest.fit(X_train, y_train)
+
+    # test different amount of test samples
+    for i in range(len(X_test)):
+        test_samples = X_test[:i+1]
+        pred_centered = fci.forestci._centered_prediction_forest(forest, test_samples)
+
+        # the vectorized solution has to match the single sample predictions
+        for n_sample, sample in enumerate(test_samples):
+            # the following assignment assures correctness of single test sample calculations
+            # no additional tests for correct averaging required since for single test samples
+            # dimension 0 (i.e. the number of test sets) disappears
+            pred_centered_sample = fci.forestci._centered_prediction_forest(
+                forest, sample)
+            assert len(pred_centered_sample[0]) == n_trees
+            npt.assert_almost_equal(
+                pred_centered_sample[0],
+                pred_centered[n_sample]
+                )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>= 1.8.2
 nose>=1.1.2
-scikit-learn>=0.17
+scikit-learn>=0.22


### PR DESCRIPTION
The confidence interval estimation failed for single test sets, as referenced in #80 

The bug has two issues that had to be solved:
1. The shape of a ndarray was not valid input for the random forest models predict method
    anymore when a single test set was provided
2. The centered prediction is calculated by substracting the average prediction (i.e. the random forest prediction) of each single trees prediction.
Previously, the average was unexpectedly calculated over the dimension of the test sets for the same tree. Instead, the average of the prediction of all single trees for one test set should be calculated.

A test has been implemented for the bugfix.
All tests passed successfully.

Additionally, the requirements file has been updated.
Due to previous changes in the master branch, the code is not compatible anymore to scikit-learn versions <0.22.
This is what another user has issued in #89 and would require users to be able to upgrade to a more recent version of the package.

