### PR TITLE
Replace deprecated fetch_mldata by fetch_openml

### DIFF
--- a/examples/plot_mpg.py
+++ b/examples/plot_mpg.py
@@ -15,22 +15,26 @@ import numpy as np
 from matplotlib import pyplot as plt
 from sklearn.ensemble import RandomForestRegressor
 import sklearn.model_selection as xval
-from sklearn.datasets.mldata import fetch_mldata
+from sklearn.datasets import fetch_openml
 import forestci as fci
 
-# Retrieve mpg data from machine learning library
-mpg_data = fetch_mldata('mpg')
+# retreive mpg data from machine learning library
+mpg_data = fetch_openml('autompg')
 
-# Separate mpg data into predictors and outcome variable
+# separate mpg data into predictors and outcome variable
 mpg_X = mpg_data["data"]
 mpg_y = mpg_data["target"]
 
-# Split mpg data into training and test set
-mpg_X_train, mpg_X_test, mpg_y_train, mpg_y_test = xval.train_test_split(
-                                                   mpg_X, mpg_y,
-                                                   test_size=0.25,
-                                                   random_state=42
-                                                   )
+# remove rows where the data is nan
+not_null_sel = np.invert(
+    np.sum(np.isnan(mpg_data["data"]), axis=1).astype(bool))
+mpg_X = mpg_X[not_null_sel]
+mpg_y = mpg_y[not_null_sel]
+
+# split mpg data into training and test set
+mpg_X_train, mpg_X_test, mpg_y_train, mpg_y_test = xval.train_test_split(mpg_X, mpg_y,
+                                                                         test_size=0.25,
+                                                                         random_state=42)
 
 # Create RandomForestRegressor
 n_trees = 2000

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import sys, os
+import warnings
 from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:
@@ -8,14 +9,12 @@ with open('requirements.txt') as f:
 try:
     import numpy
 except ImportError:
-    print('numpy is required during installation')
-    sys.exit(1)
+    warnings.warn('numpy is required during installation', ImportWarning)
 
 try:
     import scipy
 except ImportError:
-    print('scipy is required during installation')
-    sys.exit(1)
+    warnings.warn('scipy is required during installation', ImportWarning)
 
 # Get version and release info, which is all stored in forestci/version.py
 ver_file = os.path.join('forestci', 'version.py')


### PR DESCRIPTION
fetch_mldata was first deprecated and is not present anymore in the latest sklearn versions.