### PR TITLE
ENH: Allow forestci to work on general Bagging estimators

### DIFF
--- a/examples/plot_mpg.py
+++ b/examples/plot_mpg.py
@@ -19,7 +19,7 @@ from sklearn.datasets import fetch_openml
 import forestci as fci
 
 # retreive mpg data from machine learning library
-mpg_data = fetch_openml('autompg')
+mpg_data = fetch_openml(data_id=196)
 
 # separate mpg data into predictors and outcome variable
 mpg_X = mpg_data["data"]
@@ -32,9 +32,11 @@ mpg_X = mpg_X[not_null_sel]
 mpg_y = mpg_y[not_null_sel]
 
 # split mpg data into training and test set
-mpg_X_train, mpg_X_test, mpg_y_train, mpg_y_test = xval.train_test_split(mpg_X, mpg_y,
-                                                                         test_size=0.25,
-                                                                         random_state=42)
+mpg_X_train, mpg_X_test, mpg_y_train, mpg_y_test = xval.train_test_split(
+    mpg_X,
+    mpg_y,
+    test_size=0.25,
+    random_state=42)
 
 # Create RandomForestRegressor
 n_trees = 2000

--- a/examples/plot_mpg_svr.py
+++ b/examples/plot_mpg_svr.py
@@ -20,7 +20,7 @@ from sklearn.datasets import fetch_openml
 import forestci as fci
 
 # retreive mpg data from machine learning library
-mpg_data = fetch_openml("autompg")
+mpg_data = fetch_openml(data_id=196)
 
 # separate mpg data into predictors and outcome variable
 mpg_X = mpg_data["data"]

--- a/examples/plot_mpg_svr.py
+++ b/examples/plot_mpg_svr.py
@@ -1,0 +1,62 @@
+"""
+======================================
+Plotting Bagging Regression Error Bars
+======================================
+
+This example demonstrates using `forestci` to calculate the error bars of
+the predictions of a :class:`sklearn.ensemble.BaggingRegressor` object.
+
+The data used here are a classical machine learning data-set, describing
+various features of different cars, and their MPG.
+"""
+
+# Regression Forest Example
+import numpy as np
+from matplotlib import pyplot as plt
+from sklearn.ensemble import BaggingRegressor
+from sklearn.svm import SVR
+import sklearn.model_selection as xval
+from sklearn.datasets import fetch_openml
+import forestci as fci
+
+# retreive mpg data from machine learning library
+mpg_data = fetch_openml("autompg")
+
+# separate mpg data into predictors and outcome variable
+mpg_X = mpg_data["data"]
+mpg_y = mpg_data["target"]
+
+# remove rows where the data is nan
+not_null_sel = np.invert(np.sum(np.isnan(mpg_data["data"]), axis=1).astype(bool))
+mpg_X = mpg_X[not_null_sel]
+mpg_y = mpg_y[not_null_sel]
+
+# split mpg data into training and test set
+mpg_X_train, mpg_X_test, mpg_y_train, mpg_y_test = xval.train_test_split(
+    mpg_X, mpg_y, test_size=0.25, random_state=42
+)
+
+# Create RandomForestRegressor
+n_estimators = 1000
+mpg_bagger = BaggingRegressor(
+    base_estimator=SVR(), n_estimators=n_estimators, random_state=42
+)
+mpg_bagger.fit(mpg_X_train, mpg_y_train)
+mpg_y_hat = mpg_bagger.predict(mpg_X_test)
+
+# Plot predicted MPG without error bars
+plt.scatter(mpg_y_test, mpg_y_hat)
+plt.plot([5, 45], [5, 45], "k--")
+plt.xlabel("Reported MPG")
+plt.ylabel("Predicted MPG")
+plt.show()
+
+# Calculate the variance
+mpg_V_IJ_unbiased = fci.random_forest_error(mpg_bagger, mpg_X_train, mpg_X_test)
+
+# Plot error bars for predicted MPG using unbiased variance
+plt.errorbar(mpg_y_test, mpg_y_hat, yerr=np.sqrt(mpg_V_IJ_unbiased), fmt="o")
+plt.plot([5, 45], [5, 45], "k--")
+plt.xlabel("Reported MPG")
+plt.ylabel("Predicted MPG")
+plt.show()

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -1,15 +1,13 @@
 import numpy as np
 import numpy.testing as npt
 from sklearn.ensemble import RandomForestRegressor
+from sklearn.ensemble import BaggingRegressor
+from sklearn.svm import SVR
 import forestci as fci
 
 
 def test_random_forest_error():
-    X = np.array([[5, 2],
-                  [5, 5],
-                  [3, 3],
-                  [6, 4],
-                  [6, 6]])
+    X = np.array([[5, 2], [5, 5], [3, 3], [6, 4], [6, 6]])
 
     y = np.array([70, 100, 60, 100, 120])
 
@@ -27,73 +25,99 @@ def test_random_forest_error():
     inbag = fci.calc_inbag(X_train.shape[0], forest)
     for ib in [inbag, None]:
         for calibrate in [True, False]:
-            V_IJ_unbiased = fci.random_forest_error(forest, X_train, X_test,
-                                                    inbag=ib,
-                                                    calibrate=calibrate)
+            V_IJ_unbiased = fci.random_forest_error(
+                forest, X_train, X_test, inbag=ib, calibrate=calibrate
+            )
         npt.assert_equal(V_IJ_unbiased.shape[0], y_test.shape[0])
 
     # We cannot calculate inbag from a non-bootstrapped forest. This is because
     # Scikit-learn trees do not store their own sample weights. If you did This
     # some other way, you can still use your own inbag
-    non_bootstrap_forest = RandomForestRegressor(n_estimators=n_trees,
-                                                 bootstrap=False)
+    non_bootstrap_forest = RandomForestRegressor(n_estimators=n_trees, bootstrap=False)
 
-    npt.assert_raises(ValueError, fci.calc_inbag, X_train.shape[0],
-                      non_bootstrap_forest)
+    npt.assert_raises(
+        ValueError, fci.calc_inbag, X_train.shape[0], non_bootstrap_forest
+    )
+
+
+def test_bagging_svr_error():
+    X = np.array([[5, 2], [5, 5], [3, 3], [6, 4], [6, 6]])
+
+    y = np.array([70, 100, 60, 100, 120])
+
+    train_idx = [2, 3, 4]
+    test_idx = [0, 1]
+
+    y_test = y[test_idx]
+    y_train = y[train_idx]
+    X_test = X[test_idx]
+    X_train = X[train_idx]
+
+    n_trees = 4
+    bagger = BaggingRegressor(base_estimator=SVR(), n_estimators=n_trees)
+    bagger.fit(X_train, y_train)
+    inbag = fci.calc_inbag(X_train.shape[0], bagger)
+    for ib in [inbag, None]:
+        for calibrate in [True, False]:
+            V_IJ_unbiased = fci.random_forest_error(
+                bagger, X_train, X_test, inbag=ib, calibrate=calibrate
+            )
+        npt.assert_equal(V_IJ_unbiased.shape[0], y_test.shape[0])
 
 
 def test_core_computation():
-    inbag_ex = np.array([[1., 2., 0., 1.],
-                         [1., 0., 2., 0.],
-                         [1., 1., 1., 2.]])
+    inbag_ex = np.array(
+        [[1.0, 2.0, 0.0, 1.0], [1.0, 0.0, 2.0, 0.0], [1.0, 1.0, 1.0, 2.0]]
+    )
 
-    X_train_ex = np.array([[3, 3],
-                           [6, 4],
-                           [6, 6]])
-    X_test_ex = np.vstack([np.array([[5, 2],
-                                     [5, 5]]) for _ in range(1000)])
-    pred_centered_ex = np.vstack([np.array([[-20, -20, 10, 30],
-                                            [-20, 30, -20, 10]])
-                                  for _ in range(1000)])
+    X_train_ex = np.array([[3, 3], [6, 4], [6, 6]])
+    X_test_ex = np.vstack([np.array([[5, 2], [5, 5]]) for _ in range(1000)])
+    pred_centered_ex = np.vstack(
+        [np.array([[-20, -20, 10, 30], [-20, 30, -20, 10]]) for _ in range(1000)]
+    )
     n_trees = 4
 
-    our_vij = fci._core_computation(X_train_ex, X_test_ex, inbag_ex,
-                                    pred_centered_ex, n_trees)
+    our_vij = fci._core_computation(
+        X_train_ex, X_test_ex, inbag_ex, pred_centered_ex, n_trees
+    )
 
     r_vij = np.concatenate([np.array([112.5, 387.5]) for _ in range(1000)])
 
     npt.assert_almost_equal(our_vij, r_vij)
 
-    for mc, ml in zip([True, False], [.01, None]):
-        our_vij = fci._core_computation(X_train_ex, X_test_ex, inbag_ex,
-                                        pred_centered_ex, n_trees,
-                                        memory_constrained=True,
-                                        memory_limit=.01,
-                                        test_mode=True)
+    for mc, ml in zip([True, False], [0.01, None]):
+        our_vij = fci._core_computation(
+            X_train_ex,
+            X_test_ex,
+            inbag_ex,
+            pred_centered_ex,
+            n_trees,
+            memory_constrained=True,
+            memory_limit=0.01,
+            test_mode=True,
+        )
 
         npt.assert_almost_equal(our_vij, r_vij)
 
 
 def test_bias_correction():
-    inbag_ex = np.array([[1., 2., 0., 1.],
-                         [1., 0., 2., 0.],
-                         [1., 1., 1., 2.]])
+    inbag_ex = np.array(
+        [[1.0, 2.0, 0.0, 1.0], [1.0, 0.0, 2.0, 0.0], [1.0, 1.0, 1.0, 2.0]]
+    )
 
-    X_train_ex = np.array([[3, 3],
-                           [6, 4],
-                           [6, 6]])
+    X_train_ex = np.array([[3, 3], [6, 4], [6, 6]])
 
-    X_test_ex = np.array([[5, 2],
-                          [5, 5]])
+    X_test_ex = np.array([[5, 2], [5, 5]])
 
     pred_centered_ex = np.array([[-20, -20, 10, 30], [-20, 30, -20, 10]])
     n_trees = 4
 
-    our_vij = fci._core_computation(X_train_ex, X_test_ex, inbag_ex,
-                                    pred_centered_ex, n_trees)
-    our_vij_unbiased = fci._bias_correction(our_vij, inbag_ex,
-                                            pred_centered_ex,
-                                            n_trees)
+    our_vij = fci._core_computation(
+        X_train_ex, X_test_ex, inbag_ex, pred_centered_ex, n_trees
+    )
+    our_vij_unbiased = fci._bias_correction(
+        our_vij, inbag_ex, pred_centered_ex, n_trees
+    )
     r_unbiased_vij = np.array([-42.1875, 232.8125])
     npt.assert_almost_equal(our_vij_unbiased, r_unbiased_vij)
 
@@ -105,7 +129,7 @@ def test_with_calibration():
         y = np.random.rand(n // 5)
 
         train_idx = np.arange(int(n // 5 * 0.75))
-        test_idx = np.arange(int(n//5 * 0.75), n//5)
+        test_idx = np.arange(int(n // 5 * 0.75), n // 5)
 
         y_test = y[test_idx]
         y_train = y[train_idx]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy>= 1.18.4
-pandas>=1.1.5
 scikit-learn>=0.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>= 1.18.4
+pandas>=1.1.5
 scikit-learn>=0.23.1


### PR DESCRIPTION
Resolves #99 

This PR adds functionality to `forestci.py` to inspect the "forest" estimator to see if it is a random forest (i.e. inherits from `BaseForest`) or a bagging estimator (i.e. inherits from `BaseBagging`). There are some differences in the private attributes of these classes so the distinction is necessary. When the estimator is a random forest, all of the existing code applies. When it inherits from `BaseBagging`, we use the `.estimators_samples_` attribute for the `calc_inbag` function. And when calibrating inside `random_forest_error`, it is also necessary to randomly permute the `_seeds` array attribute of `new_forest`. I've also added some tests for these new features.

I believe this PR makes forestci work well with general bagging estimators. However, I would greatly appreciate it if @arokem, @kpolimis, @bhazelton could check my work here. Most importantly, is this sensible? I think I've made the APIs compatible but am I making a mistake in applying Wager's method to general bagging methods (and not exclusively to random forests)?