### PR TITLE
Handle only one test sample and warn the user about CI accuracy

### DIFF
--- a/forestci/calibration.py
+++ b/forestci/calibration.py
@@ -73,7 +73,7 @@ def gfit(X, sigma, p=5, nbin=200, unif_fraction=0.1):
     else:
         noise_rotate = noise_kernel
 
-    XX = np.zeros((p, len(xvals)), dtype=np.float)
+    XX = np.zeros((p, len(xvals)), dtype="float")
     for ind, exp in enumerate(range(1, p+1)):
         mask = np.ones_like(xvals)
         mask[np.where(xvals <= 0)[0]] = 0

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -325,7 +325,9 @@ def random_forest_error(
         return V_IJ_unbiased
 
     if V_IJ_unbiased.shape[0] <= 20:
-        print("No calibration with n_samples <= 20: consider using more n_estimators in your model, for more accurate ci and to avoid negative values.")
+        print("No calibration with n_samples <= 20: ", 
+                 "consider using more n_estimators in your model, ", 
+                 "for more accurate ci and to avoid negative values.")
         return V_IJ_unbiased
     if calibrate:
         # Calibration is a correction for converging quicker to the case of infinite n_estimators,

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -236,7 +236,7 @@ def random_forest_error(forest, X_train, X_test, inbag=None,
         inbag = calc_inbag(X_train.shape[0], forest)
 
     pred = np.array([tree.predict(X_test) for tree in forest]).T
-    pred_mean = np.mean(pred, 0)
+    pred_mean = np.mean(pred, 1).reshape(X_test.shape[0], 1)
     pred_centered = pred - pred_mean
     n_trees = forest.n_estimators
     V_IJ = _core_computation(X_train, X_test, inbag, pred_centered, n_trees,

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -325,10 +325,11 @@ def random_forest_error(
         return V_IJ_unbiased
 
     if V_IJ_unbiased.shape[0] <= 20:
-        print("No calibration with n_samples <= 20")
+        print("No calibration with n_samples <= 20: consider using more n_estimators in your model, for more accurate ci and to avoid negative values.")
         return V_IJ_unbiased
     if calibrate:
-
+        # Calibration is a correction for converging quicker to the case of infinite n_estimators,
+        # as presented in Wager (2014) http://jmlr.org/papers/v15/wager14a.html
         calibration_ratio = 2
         n_sample = np.ceil(n_trees / calibration_ratio)
         new_forest = copy.deepcopy(forest)

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -117,3 +117,43 @@ def test_with_calibration():
         forest.fit(X_train, y_train)
         V_IJ_unbiased = fci.random_forest_error(forest, X_train, X_test)
         npt.assert_equal(V_IJ_unbiased.shape[0], y_test.shape[0])
+
+
+def test_centered_prediction_forest():
+    X = np.array([[5, 2],
+                  [5, 5],
+                  [3, 3],
+                  [6, 4],
+                  [6, 6]])
+
+    y = np.array([70, 100, 60, 100, 120])
+
+    train_idx = [2, 3, 4]
+    test_idx = [0, 1]
+
+    y_test = y[test_idx]
+    y_train = y[train_idx]
+    X_test = X[test_idx]
+    X_train = X[train_idx]
+
+    n_trees = 8
+    forest = RandomForestRegressor(n_estimators=n_trees)
+    forest = forest.fit(X_train, y_train)
+
+    # test different amount of test samples
+    for i in range(len(X_test)):
+        test_samples = X_test[:i+1]
+        pred_centered = fci.forestci._centered_prediction_forest(forest, test_samples)
+
+        # the vectorized solution has to match the single sample predictions
+        for n_sample, sample in enumerate(test_samples):
+            # the following assignment assures correctness of single test sample calculations
+            # no additional tests for correct averaging required since for single test samples
+            # dimension 0 (i.e. the number of test sets) disappears
+            pred_centered_sample = fci.forestci._centered_prediction_forest(
+                forest, sample)
+            assert len(pred_centered_sample[0]) == n_trees
+            npt.assert_almost_equal(
+                pred_centered_sample[0],
+                pred_centered[n_sample]
+                )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>= 1.8.2
 nose>=1.1.2
-scikit-learn>=0.17
+scikit-learn>=0.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy>= 1.18.4
+numpy>=1.20
 scikit-learn>=0.23.1


### PR DESCRIPTION
Hi,
I rebased the nice work of @cewaphi (https://github.com/scikit-learn-contrib/forest-confidence-interval/pull/90) on the most updated master, which is now ready to merge.
His work allow having problems when computing the confidence interval of only one test sample.

Second I updated the requirement to a more recent `numpy` version, which has the different API using `dtype="float"` instead of `dtype=np.float`.

Third, seen the many complains about negative results (e.g., https://github.com/scikit-learn-contrib/forest-confidence-interval/issues/25, still happening despite the fix), we now suggest the user to increase the number of `n_estimators` in his model: indeed, Wager2014 introduces the calibration as a way to reach the limit case of infinite baggers with a finite number of `n_estimators` (=baggers).

There is still the issue of:
```
forestci/tests/test_forestci.py::test_with_calibration
  /Users/danieleongari/Programs/forest-confidence-interval/forestci/calibration.py:86: RuntimeWarning: overflow encountered in exp
    g_eta_raw = np.exp(np.dot(XX, eta)) * mask

forestci/tests/test_forestci.py::test_with_calibration
  /Users/danieleongari/opt/anaconda3/lib/python3.8/site-packages/numpy/core/fromnumeric.py:86: RuntimeWarning: overflow encountered in reduce
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
```
raising randomly for some 70% of the runs.
If it is a relevant problem, and increasing `n_estimators` also fixes this issue, you could consider to warn the user also in these cases when overflow happens.

Thanks for your attention, I hope this was helpful and that this PR will get merged soon.

Daniele