### PR TITLE
Handle MultiOutput model

### DIFF
--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -224,10 +224,11 @@ def _centered_prediction_forest(forest, X_test):
         mean prediction (i.e. the prediction of the forest)
 
     """
-    # reformatting required for single sample arrays
-    # caution: assumption that number of features always > 1
+    # In case the user provided a (n_features)-shaped array for a single sample
+    #  shape it as (1, n_features)
+    # NOTE: a single-feature set of samples needs to be provided with shape
+    #       (n_samples, 1) or it will be wrongly interpreted!
     if len(X_test.shape) == 1:
-        # reshape according to the reshaping annotation in scikit-learn
         X_test = X_test.reshape(1, -1)
 
     pred = np.array([tree.predict(X_test) for tree in forest]).T

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -231,10 +231,10 @@ def _centered_prediction_forest(forest, X_test):
     if len(X_test.shape) == 1:
         X_test = X_test.reshape(1, -1)
 
-    pred = np.array([tree.predict(X_test) for tree in forest]).T
-    pred_mean = np.mean(pred, 1).reshape(X_test.shape[0], 1)
+    pred = np.array([tree.predict(X_test) for tree in forest])
+    pred_mean = np.mean(pred, 0)
 
-    return pred - pred_mean
+    return (pred - pred_mean).T
 
 
 def random_forest_error(

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -316,7 +316,7 @@ def random_forest_error(
        of Machine Learning Research vol. 15, pp. 1625-1651, 2014.
     """
 
-    if forest.n_outputs_ > 1 and y_output == None:
+    if 'n_outputs_' in dir(forest) and forest.n_outputs_ > 1 and y_output == None:
         e_s = "MultiOutput regressor: specify the index of the target to analyse (y_output)"
         raise ValueError(e_s)
 

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -232,7 +232,7 @@ def _centered_prediction_forest(forest, X_test, y_output=None):
         X_test = X_test.reshape(1, -1)
 
     pred = np.array([tree.predict(X_test) for tree in forest])
-    if forest.n_outputs_ > 1:
+    if 'n_outputs_' in dir(forest) and forest.n_outputs_ > 1:
         pred = pred[:,:,y_output]
 
     pred_mean = np.mean(pred, 0)

--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -200,7 +200,7 @@ def _bias_correction(V_IJ, inbag, pred_centered, n_trees):
     return V_IJ_unbiased
 
 
-def _centered_prediction_forest(forest, X_test, y_output):
+def _centered_prediction_forest(forest, X_test, y_output=None):
     """
     Center the tree predictions by the mean prediction (forest)
 

--- a/forestci/tests/test_forestci.py
+++ b/forestci/tests/test_forestci.py
@@ -40,6 +40,43 @@ def test_random_forest_error():
     )
 
 
+def test_random_forest_error_multioutput():
+    X = np.array([[5, 2], [5, 5], [3, 3], [6, 4], [6, 6]])
+
+    y = np.array([[70, 37], [100, 55], [60, 33], [100,54], [120, 66]])
+
+    train_idx = [2, 3, 4]
+    test_idx = [0, 1]
+
+    y_test = y[test_idx]
+    y_train = y[train_idx]
+    X_test = X[test_idx]
+    X_train = X[train_idx]
+
+    n_trees = 4
+    forest = RandomForestRegressor(n_estimators=n_trees)
+    forest.fit(X_train, y_train)
+    
+    V_IJ_unbiased_target0 = fci.random_forest_error(
+        forest, X_train.shape, X_test, calibrate=True, y_output=0
+    )
+    npt.assert_equal(V_IJ_unbiased_target0.shape[0], y_test.shape[0])
+
+    # With a MultiOutput RandomForestRegressor the user MUST specify a y_output
+    npt.assert_raises(
+        ValueError, 
+        fci.random_forest_error, 
+        forest,
+        X_train.shape,
+        X_test,
+        inbag=None,
+        calibrate=True,
+        memory_constrained=False,
+        memory_limit=None,
+        y_output=None # This should trigger the ValueError
+    )
+
+
 def test_bagging_svr_error():
     X = np.array([[5, 2], [5, 5], [3, 3], [6, 4], [6, 6]])
 


### PR DESCRIPTION
Hi,
I suggest this modification to handle with multi-output estimators.
This will solve Issue https://github.com/scikit-learn-contrib/forest-confidence-interval/issues/54, i.e., the oldest open issue on this repo!

Scikit-Learn's `RandomForestRegressor` can automatically switch to a MultiOutput model if the y_train contains multiple targets. However ,`forest-confidence-interval` could not handle them.

One solution would imply to compute and return a 2-dim array with the variance for each target, for each sample.
However, this would break some past compatibility (because it would make sense to print a 2-d (1,N)-array even with one target) but especially, it would require an extensive check on all the tensors operations.
What I propose here is to input `y_output` (int), telling the program which output to use.
This may not be the most efficient solution, as there is some redundancy in `running random_forest_error()` if you want to run it for each output... but it is very intuitive to understand, totally back-compatible, and a simple modification.

Thanks again for this nice project, to which I'm happy to contribute for the second time.
I hope this gets merged soon.

Daniele 