### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install git+git://github.com/scikit-learn-contrib/forest-confidence-interval
 Usage:
 
 ```python
-import import forestci as fci
+import forestci as fci
 ci = fci.random_forest_error(
   forest=model, # scikit-learn Forest model fitted on X_train
   X_train_shape=X_train.shape,


### PR DESCRIPTION
Hi, there was an extra `import` in the README.md. :)