### PR TITLE
Fix compatibility with scikit-learn 1.9 (sample_weight signature change)

### DIFF
--- a/forestci/forestci.py
+++ b/forestci/forestci.py
@@ -8,13 +8,25 @@ RandomForestClassifier predictions.
 import numpy as np
 import copy
 
+import sklearn
 from sklearn.ensemble._forest import BaseForest
 from sklearn.ensemble._forest import (_generate_sample_indices,
                                       _get_n_samples_bootstrap)
 from sklearn.ensemble._bagging import BaseBagging
+from sklearn.utils.fixes import parse_version
 
 from .calibration import calibrateEB
 from .due import _due, _BibTeX
+
+# scikit-learn 1.9 made `sample_weight` a required argument of the private
+# helpers `_get_n_samples_bootstrap` and `_generate_sample_indices`
+# (https://github.com/scikit-learn/scikit-learn/pull/31529). Passing None
+# reproduces the previous uniform-bootstrap behavior. Compare against
+# "1.9.0.dev0" so 1.9 pre-releases (which already carry the new signature and
+# sort before the final under PEP 440) are also covered.
+_SKLEARN_GE_19 = (
+    parse_version(sklearn.__version__) >= parse_version("1.9.0.dev0")
+)
 
 __all__ = ("calc_inbag", "random_forest_error", "_bias_correction",
            "_core_computation")
@@ -70,16 +82,34 @@ def calc_inbag(n_samples, forest):
     inbag = np.zeros((n_samples, n_trees))
     sample_idx = []
     if isinstance(forest, BaseForest):
-        n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, forest.max_samples)
+        if _SKLEARN_GE_19:
+            n_samples_bootstrap = _get_n_samples_bootstrap(
+                n_samples, forest.max_samples, None
+            )
+        else:
+            n_samples_bootstrap = _get_n_samples_bootstrap(
+                n_samples, forest.max_samples
+            )
 
         for t_idx in range(n_trees):
-            sample_idx.append(
-                _generate_sample_indices(
-                    forest.estimators_[t_idx].random_state,
-                    n_samples,
-                    n_samples_bootstrap,
+            random_state = forest.estimators_[t_idx].random_state
+            if _SKLEARN_GE_19:
+                sample_idx.append(
+                    _generate_sample_indices(
+                        random_state,
+                        n_samples,
+                        n_samples_bootstrap,
+                        None,
+                    )
                 )
-            )
+            else:
+                sample_idx.append(
+                    _generate_sample_indices(
+                        random_state,
+                        n_samples,
+                        n_samples_bootstrap,
+                    )
+                )
             inbag[:, t_idx] = np.bincount(sample_idx[-1], minlength=n_samples)
     elif isinstance(forest, BaseBagging):
         for t_idx, estimator_sample in enumerate(forest.estimators_samples_):


### PR DESCRIPTION
## Summary

Fixes #121. `calc_inbag()` calls scikit-learn's private `_get_n_samples_bootstrap` and `_generate_sample_indices` with their pre-1.9 signatures. scikit-learn 1.9 ([scikit-learn#31529](https://github.com/scikit-learn/scikit-learn/pull/31529)) made `sample_weight` a **required** positional argument on both, so `random_forest_error(..., inbag=None)` raises `TypeError` on scikit-learn >= 1.9. There is currently no version guard.

## Change

A module-level `_SKLEARN_GE_19` flag (via `sklearn.utils.fixes.parse_version`, so no new dependency) gates both calls in `calc_inbag`, passing `sample_weight=None` on >= 1.9. `None` reproduces the previous uniform-bootstrap behavior (identical `randint` draw and unweighted `max_samples` semantics), so this is a pure compatibility fix with **no behavior change on any version**. The comparison uses `"1.9.0.dev0"` so 1.9 release candidates — which already carry the new signature and sort before the final under PEP 440 — are also covered.

## Testing

- `pytest forestci` — **7 passed** on scikit-learn 1.9.0.
- The minimal repro from #121 now succeeds:

```python
import numpy as np
from sklearn.ensemble import RandomForestRegressor
import forestci as fci

rng = np.random.RandomState(0)
X, y = rng.rand(100, 5), rng.rand(100)
rf = RandomForestRegressor(n_estimators=50, random_state=0).fit(X, y)
fci.random_forest_error(rf, X.shape, X)  # -> finite, non-negative variances
```

Found while adding scikit-learn 1.9 support downstream in [uber/causalml](https://github.com/uber/causalml).
